### PR TITLE
Fix Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This driver, provided by Realtek itself, worked for me to prevent the ASPM bug. 
 # Installation
 Please remove/save your old r8169 module before installing this module. Its in 
 ```
-/var/lib/modules/($uname -r)/kernel/drivers/net/ethernet/realtek/r8169.ko.gz
+/var/lib/modules/$(uname -r)/kernel/drivers/net/ethernet/realtek/r8169.ko.gz
 ```
 for me.
 


### PR DESCRIPTION
The `$` should be outside the `()` in `/var/lib/modules/($uname -r)/kernel/drivers/net/ethernet/realtek/r8169.ko.gz`

```
chankruze@geekofia:~$ /var/lib/modules/($uname -r)/kernel/drivers/net/ethernet/realtek/r8169.ko.gz
bash: syntax error near unexpected token `$uname'
chankruze@geekofia:~$ uname -r
5.0.0-17-generic
chankruze@geekofia:~$ /var/lib/modules/$(uname -r)/kernel/drivers/net/ethernet/realtek/r8169.ko.gz
bash: /var/lib/modules/5.0.0-17-generic/kernel/drivers/net/ethernet/realtek/r8169.ko.gz: No such file or directory
chankruze@geekofia:~$
```